### PR TITLE
fix: slider skipped key tab and keyboard navigation

### DIFF
--- a/src/components/slider/handle.js
+++ b/src/components/slider/handle.js
@@ -62,7 +62,7 @@ class Handle extends Component {
             onMouseLeave: this.onMouseLeave,
           })}
         />
-        <div
+        <button
           role="slider"
           aria-valuemin={min}
           aria-valuemax={max}
@@ -80,6 +80,7 @@ class Handle extends Component {
             boxShadow: '1px 1px 1px 1px rgba(0, 0, 0, 0.2)',
             backgroundColor: disabled ? trasnsparent : '#fff',
           }}
+          {...getHandleProps(id)}
         />
       </Fragment>
     )


### PR DESCRIPTION
Issues: #44 #39 
I only add a button and share the props with this component. And it's work.
Check the gif.
https://media.giphy.com/media/U3t5cCTmigxU3epx9A/giphy.gif