### PR TITLE
i18n: add react-localization support for strings

### DIFF
--- a/examples/index.js
+++ b/examples/index.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
+import Localization from '../src/localize'
 
 // Remplace path with build
 import Villain from '../src/index.js'
@@ -17,7 +18,7 @@ const testFile = '/build/testFile/Example-archive.zip'
 
 ReactDOM.render(
   <div>
-    <h1> Test example! </h1>
+    <h1> {Localization['example.header']} </h1>
     <Villain file={testFile} options={villainOpts} />
   </div>,
   document.getElementById('app')

--- a/examples/index.js
+++ b/examples/index.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
-import Localization from '../src/localize'
+import Localization from '@/src/localize'
 
 // Remplace path with build
 import Villain from '../src/index.js'

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "prop-types": "^15.7.2",
     "react": "^16.8.6",
     "react-compound-slider": "^2.3.0",
-    "react-dom": "^16.8.6"
+    "react-dom": "^16.8.6",
+    "react-localization": "^1.0.15"
   },
   "devDependencies": {
     "@babel/core": "^7.4.4",

--- a/src/locales/messages.json
+++ b/src/locales/messages.json
@@ -1,6 +1,7 @@
 {
   "pagination.prev": "Previous page",
   "pagination.next": "Next page",
+  "pagination.page": "Page",
   "pin.toolbar": "Pin controls",
   "fullscreen.on": "Enter fullscreen",
   "fullscreen.off": "Exit fullscreen",
@@ -9,5 +10,6 @@
   "theme.light": "Light theme",
   "theme.dark": "Dark theme",
   "zoom.in": "Zoom in",
-  "zoom.out": "Zoom out"
+  "zoom.out": "Zoom out",
+  "example.header": "Example test!"
 }

--- a/src/locales/messages.ru.json
+++ b/src/locales/messages.ru.json
@@ -1,0 +1,15 @@
+{
+  "pagination.prev": "Предыдущая",
+  "pagination.next": "Следующая",
+  "pagination.page": "Страница",
+  "pin.toolbar": "Закрепить панель инструментов",
+  "fullscreen.on": "На весь экран",
+  "fullscreen.off": "Выйти из полноэкранного режима",
+  "view.bookmode": "Книжный вид",
+  "view.singlepage": "Страничный вид",
+  "theme.light": "Светлая тема",
+  "theme.dark": "Темная тема",
+  "zoom.in": "Увеличить",
+  "zoom.out": "Уменьшить",
+  "example.header": "Тестовый пример!"
+}

--- a/src/localize.js
+++ b/src/localize.js
@@ -1,0 +1,11 @@
+// ES6 module syntax
+import LocalizedStrings from 'react-localization'
+
+const Localization = new LocalizedStrings({
+  en: require('@/locales/messages.json'),
+  de: require('@/locales/messages.de.json'),
+  pt: require('@/locales/messages.pt.json'),
+  ru: require('@/locales/messages.ru.json'),
+})
+
+export default Localization

--- a/yarn.lock
+++ b/yarn.lock
@@ -4982,6 +4982,11 @@ loader-utils@^0.2.16:
     json5 "^0.5.0"
     object-assign "^4.0.1"
 
+localized-strings@^0.2.0:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/localized-strings/-/localized-strings-0.2.3.tgz#6caed1bc0476668331ed4e96729676ae8f7a0295"
+  integrity sha512-uWO3E2jDynMBsJIglBMhALO3f1DnfOFzCSoCt+fPLGx94PXU1KfbgBx04J4xfjPwozRowAHk8bfaw8bgeKTTCQ==
+
 locate-path@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-2.0.0.tgz#2b568b265eec944c6d9c0de9c3dbbbca0354cd8e"
@@ -6798,6 +6803,13 @@ react-is@^16.10.2, react-is@^16.8.1, react-is@^16.8.4, react-is@^16.8.6, react-i
   version "16.10.2"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.10.2.tgz#984120fd4d16800e9a738208ab1fba422d23b5ab"
   integrity sha512-INBT1QEgtcCCgvccr5/86CfD71fw9EPmDxgiJX4I2Ddr6ZsV6iFXsuby+qWJPtmNuMY0zByTsG4468P7nHuNWA==
+
+react-localization@^1.0.15:
+  version "1.0.15"
+  resolved "https://registry.yarnpkg.com/react-localization/-/react-localization-1.0.15.tgz#624bd0b514100488a84204e20b398750313d1708"
+  integrity sha512-s+yK3EqPUhN8kAfUIoA5m0a0iGOvxB3DrvngYnSZNLRQRX+yS7LYfTuKT66KVa3Cr6EP4iGRtw4XRqpsi1ZLjw==
+  dependencies:
+    localized-strings "^0.2.0"
 
 react-test-renderer@^16.0.0-0:
   version "16.10.2"


### PR DESCRIPTION
## PR Checklist

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change

## PR Type

What kind of change does this PR introduce?

- [x] Feature

## Fixes

Issue Number: https://github.com/btzr-io/Villain/issues/92

## What is the new behavior?
Now you can import `Localization` for translated strings.

## Other information
I've tried to implement this using existent `src/locales/messages*.js` files, don't know if it's correct decision. See `example/index.js`. Also, added Russian translation.