### PR TITLE
Fix tooltip position

### DIFF
--- a/src/components/toolbar/navigation.js
+++ b/src/components/toolbar/navigation.js
@@ -73,6 +73,7 @@ class Navigation extends Component {
         <Button
           type={'icon'}
           tooltip={mangaMode ? 'Next Page' : 'Previous Page'}
+          tooltipClass="left-edge"
           onClick={mangaMode ? navigateForward : navigateBackward}
           disabled={mangaMode ? isLastPage : isFirstPage}
           icon={mdiChevronLeft}

--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -163,6 +163,9 @@
   ); /* Position the tooltip vertically to match other elements (11px) */
 }
 
+.tooltip-con.top-edge {
+  bottom: -240%;
+}
 .tooltip-con.right-edge {
   left: -120%;
 }


### PR DESCRIPTION
## PR Checklist

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

## Fixes

Issue Number: #94 

## What is the current behavior?
Tooltip may go off screen
## What is the new behavior?
The tooltip will not go off screen.
![изображение](https://user-images.githubusercontent.com/20929004/67176423-99c4bd00-f3d2-11e9-999a-1dffddaeda0c.png)
 
## Other information
I used the **tooltipClass**  property of **Button** (which uses **overrideClass** of **Tooltip**) to set correct class (_.left-edge_). 
I also added style for _.tooltip-con.top-edge_ which can be used if tooltip is on top.
