### PR TITLE
Fix rapid arrow navigation crashing the viewer

### DIFF
--- a/src/components/toolbar/index.js
+++ b/src/components/toolbar/index.js
@@ -63,7 +63,6 @@ class Toolbar extends Component {
         toggleFullscreen('fullscreen')
         break
 
-      /*  Note: This shortcuts break the viewewr.
       // Navigation to next page
       case 'ArrowRight':
         if (!isLastPage) navigateToPage(currentPage + 1)
@@ -73,7 +72,6 @@ class Toolbar extends Component {
       case 'ArrowLeft':
         if (!isFirstPage) navigateToPage(currentPage - 1)
         break
-      */
     }
   }
 

--- a/src/components/toolbar/zoom.js
+++ b/src/components/toolbar/zoom.js
@@ -51,10 +51,10 @@ class ZoomControls extends Component {
     }
   }
 
-  componentDidUpdate(prevProps) {
-    const { currentZoom } = this.props
-    if (currentZoom !== prevProps.currentZoom) {
-      this.setState({ value: `${currentZoom}%` })
+  static getDerivedStateFromProps(props) {
+    const { currentZoom } = props
+    return {
+      value: `${currentZoom}%`,
     }
   }
 


### PR DESCRIPTION
## PR Checklist

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

## Fixes

Issue Number: #104 

## What is the current behavior?

Rapid arrow key presses cause an error due to state changes on prop updates

## What is the new behavior?

The state is now derived from the props, removing the error. The user can now rapidly navigate using the arrow keys

## Other information

I didn't add a debounce as it was not needed to fix the error. Let me know if you want a debounce added as well