### PR TITLE
[Issue - #120] - fix: don't call toggleFullscreen if allowFullScreen is set to false

### DIFF
--- a/src/components/render.js
+++ b/src/components/render.js
@@ -171,8 +171,8 @@ class CanvasRender extends Component {
   }
 
   toggleFullscreen = () => {
-    const { container } = this.props
-    toggleFullscreen(container)
+    const { container, allowFullScreen } = this.props
+    if (allowFullScreen) toggleFullscreen(container)
   }
 
   initOpenSeaDragon() {


### PR DESCRIPTION
## PR Checklist

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix

## Fixes

Issue Number: #120 

## What is the current behavior?
Even if `allowFullScreen` prop is set to `false`, if `f` key is pressed, full-screen mode will be called 

## What is the new behavior?
full-screen mode will not be called when `f` key is pressed if `allowFullScreen` is `false`