### PR TITLE
Fixed bug on slider bar and re-render page when mangaMode is changed

### DIFF
--- a/src/components/render.js
+++ b/src/components/render.js
@@ -355,8 +355,9 @@ class CanvasRender extends Component {
       }
     }
 
+    // re-render page when mangaMode is changed
     if (mangaMode !== prevProps.mangaMode) {
-      this.context.updateState({ mangaMode })
+      this.context.updateState({ mangaMode }, () => this.renderPage(currentPage))
     }
   }
 

--- a/src/components/slider/index.js
+++ b/src/components/slider/index.js
@@ -67,9 +67,9 @@ class SliderUI extends Component {
   }
 
   onChange = values => {
-    this.props.onChange(values[0] - 1)
     // Stop seeking
     this.setState({ seeking: false })
+    this.props.onChange(values[0] - 1)
   }
 
   componentDidUpdate(prevProps) {

--- a/src/context.js
+++ b/src/context.js
@@ -30,8 +30,8 @@ export class ReaderProvider extends Component {
   //Define deafault state and  merge external values
   state = { ...defaultState, ...this.props.defaultState }
 
-  updateState = data => {
-    this.setState(data)
+  updateState = (data, callback) => {
+    this.setState(data, callback)
   }
 
   toggleSetting = setting => {


### PR DESCRIPTION
## PR Checklist

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

## Fixes

Issue Number: #124 

## What is the current behavior?
- Manga mode ignores the current page when dragging the slider.
- Book mode is not showing the inverted layout when manga mode is changed.

## What is the new behavior?
- Manga mode keeps the current page when dragging the slider.
- Re-render page when manga mode is changed.

## Other information
