### PR TITLE
Invert navigation shortcuts while in mangaMode

### DIFF
--- a/src/components/toolbar/index.js
+++ b/src/components/toolbar/index.js
@@ -55,8 +55,11 @@ class Toolbar extends Component {
       return
     }
 
-    const { toggleSetting, navigateToPage } = this.context
-    const { isFirstPage, isLastPage, currentPage } = this.context.state
+    const { toggleSetting, navigateForward, navigateBackward } = this.context
+    const { mangaMode } = this.context.state
+
+    const navigateRight = mangaMode ? navigateBackward : navigateForward
+    const navigateLeft = mangaMode ? navigateForward : navigateBackward
 
     switch (key) {
       // Toggle fullscreen of viewer.
@@ -67,14 +70,14 @@ class Toolbar extends Component {
         toggleFullscreen()
         break
 
-      // Navigation to next page
+      // Navigation to next page (previous when in mangaMode)
       case 'ArrowRight':
-        if (!isLastPage) navigateToPage(currentPage + 1)
+        navigateRight()
         break
 
-      // Navigation to previous page
+      // Navigation to previous page (next when in mangaMode)
       case 'ArrowLeft':
-        if (!isFirstPage) navigateToPage(currentPage - 1)
+        navigateLeft()
         break
     }
   }


### PR DESCRIPTION
## PR Checklist

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

## Fixes

Issue Number: #133

## What is the current behavior?
Pressing right always goes to the next page.
Pressing left always goes to the previous page.

## What is the new behavior?
While **not** in mangaMode, the current behavior is preserved.
While in mangaMode, pressing right goes to the previous page, and pressing left goes to the next page.

## Other information
In `handleShortcuts`, `navigateToPage` was replaced with `navigateForward` and `navigateBackward` for simplicity.