### PR TITLE
Remove unused imports and duplicate zIndex

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,6 @@ typings/
 
 # Test files
 build/test_files
+
+# IDE files
+.idea/

--- a/src/components/renderError.js
+++ b/src/components/renderError.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react'
+import React from 'react'
 import Icon from '@mdi/react'
 
 const Error = React.memo(props => {

--- a/src/components/slider/sliderRail.js
+++ b/src/components/slider/sliderRail.js
@@ -1,6 +1,5 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
-import Tooltip from './tooltip'
 
 const railStyle = {
   position: 'absolute',
@@ -8,7 +7,6 @@ const railStyle = {
   width: '100%',
   height: '100%',
   cursor: 'pointer',
-  zIndex: 300,
   borderRadius: '4px',
   backgroundColor: 'var(--slider-bg)',
   zIndex: -1,

--- a/src/components/toolbar/navigation.js
+++ b/src/components/toolbar/navigation.js
@@ -1,4 +1,4 @@
-import React, { Component, useState, useContext, useEffect, useRef } from 'react'
+import React, { useState, useContext, useEffect, useRef } from 'react'
 import Button from './button'
 import { ReaderContext } from '@/context'
 import { mdiChevronLeft, mdiChevronRight } from '@mdi/js'

--- a/src/components/uncompress.js
+++ b/src/components/uncompress.js
@@ -1,4 +1,4 @@
-import React, { Component, useContext, useState, useEffect } from 'react'
+import React, { useContext, useState, useEffect } from 'react'
 import PropTypes from 'prop-types'
 import { Archive } from 'libarchive.js/main'
 import { asyncForEach, fetchArchive, isValidImageType } from '@/lib/utils'


### PR DESCRIPTION
## PR Checklist

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [x] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

Found some unused imports left over from the hook migration, and found a duplicate zIndex due to the zIndex fix merged 8 hours ago.
