### PR TITLE
177: only include dist in published package

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "type": "git",
     "url": "git+https://github.com/btzr-io/Villain.git"
   },
+  "files": ["dist/"],
   "keywords": [
     "react"
   ],


### PR DESCRIPTION
PR Checklist

Please check all that apply to this PR using "x":

- [X] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [X] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [X] Other - Please describe: Change to build behavior

## Fixes

Issue Number: #177 

## What is the current behavior?
The current behavior is that the build includes all files when we only need to include files in the `dist` directory in the published package.

## What is the new behavior?
The new behavior only includes files in the `dist` directory in the published package.

## Other information
* The suggested change was to add an .npmignore file as a blacklist to prevent the inclusion of unwanted files/directories. Since a whitelist would be shorter and easier to manage, I decided to add a [files](https://docs.npmjs.com/files/package.json#files) array to the package.json. 
* I tested this change by running `npm pack` in the project root, and it showed the package only included 7 files as opposed to the 68 it included before this change.

