### PR TITLE
fix: font-family variable

### DIFF
--- a/src/css/components/input.css
+++ b/src/css/components/input.css
@@ -3,7 +3,7 @@
   text-align: right;
   max-width: 38px;
   font-size: 14px;
-  font-family: var(--font-fami]y);
+  font-family: var(--font-family);
   font-weight: 700;
   background: var(--input-bg);
   border: 0;


### PR DESCRIPTION
## PR Checklist

Please check all that apply to this PR using "x":

- [X] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [X] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

## Fixes

Issue Number:

## What is the current behavior?
Error in building
```
ERROR in ./src/css/components/input.css (./node_modules/css-loader/dist/cjs.js!./node_modules/sass-loader/dist/cjs.js!./src/css/components/input.css)
Module build failed (from ./node_modules/sass-loader/dist/cjs.js):
SassError: Invalid CSS after "...var(--font-fami": expected expression (e.g. 1px, bold), was "]y);"
        on line 6 of /Users/lucas/Documents/github/forks/Villain/src/css/components/input.css
>>   font-family: var(--font-fami]y);

   ---------------------^

 @ ./src/css/components/input.css 1:14-129 20:4-31:5 23:25-140
 @ ./src/css/index.js
 @ ./src/index.js
 @ ./examples/demo.js
 @ ./examples/index.js
ℹ ｢wdm｣: Failed to compile.
```

## What is the new behavior?
It compiles without errors.
