### PR TITLE
fix: Fix Toolbar focus moving with arrow keys

### DIFF
--- a/src/components/toolbar/index.js
+++ b/src/components/toolbar/index.js
@@ -168,6 +168,7 @@ const Toolbar = ({
           disabled={renderError}
           tooltip={autoHideControls ? Localize['Pin toolbar'] : Localize['Unpin toolbar']}
           as={Button}
+          focusable
         />
 
         <ToolbarItem
@@ -179,6 +180,7 @@ const Toolbar = ({
           tooltip={bookMode ? Localize['Page view'] : Localize['Book view']}
           tooltipPlacement={allowFullScreen ? 'top' : 'top-end'}
           as={Button}
+          focusable
         />
 
         {allowFullScreen && (
@@ -193,6 +195,7 @@ const Toolbar = ({
             }
             tooltipPlacement={'top-end'}
             as={Button}
+            focusable
           />
         )}
       </div>

--- a/src/components/toolbar/navigation.js
+++ b/src/components/toolbar/navigation.js
@@ -83,6 +83,7 @@ const Navigation = ({ toolbarItemProps }) => {
         tooltip={mangaMode ? Localize['Next page'] : Localize['Previous page']}
         tooltipPlacement={'top-start'}
         as={Button}
+        focusable
       />
       <ToolbarItem
         {...toolbarItemProps}
@@ -92,6 +93,7 @@ const Navigation = ({ toolbarItemProps }) => {
         disabled={mangaMode ? isFirstPage : isLastPage}
         tooltip={mangaMode ? Localize['Next page'] : Localize['Next page']}
         as={Button}
+        focusable
       />
 
       <div className={'wrapper-input'} data-focus={focusState} onClick={handleClick}>
@@ -115,6 +117,7 @@ const Navigation = ({ toolbarItemProps }) => {
           onKeyPress={handleKeyPress}
           value={state.value}
           as={'input'}
+          focusable
         />
         <div className={'villain-label villain-label--center'}>{'/'}</div>
         <div className={'villain-label'}>{`${totalPages}`}</div>

--- a/src/components/toolbar/zoom.js
+++ b/src/components/toolbar/zoom.js
@@ -88,6 +88,7 @@ const ZoomControls = ({ disabled, onUpdate, toolbarItemProps }) => {
         disabled={!canZoomIn || disabled}
         onClick={triggerIncrement}
         as={Button}
+        focusable
       />
       <ToolbarItem
         {...toolbarItemProps}
@@ -97,6 +98,7 @@ const ZoomControls = ({ disabled, onUpdate, toolbarItemProps }) => {
         disabled={!canZoomOut || disabled}
         onClick={triggerDecrement}
         as={Button}
+        focusable
       />
 
       {/* This wrapper is used to force an update for the initial value and when the zoom buttons trigger a change */}
@@ -120,6 +122,7 @@ const ZoomControls = ({ disabled, onUpdate, toolbarItemProps }) => {
           disabled={disabled}
           value={state.value}
           as={'input'}
+          focusable
         />
 
         <div className={'villain-label villain-label--center'}>%</div>


### PR DESCRIPTION
## PR Checklist

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

## Fixes

- Fix `Toolbar` focus movement using arrow keys.

## What is the current behavior?

Only the underlying `Button` receives the `focusable` prop. All that `ToolbarItem` knows is that it's `disabled`. `disabled` items are not added to the toolbar focus group.

As you can see on the GIF below, we can't reach `disabled` items (like the `-` zoom button) using arrow keys.

![Nov-08-2019 01-34-02](https://user-images.githubusercontent.com/3068563/68450048-48853d80-01c8-11ea-8ab7-eaf468f4a0f8.gif)

## What is the new behavior?

`ToolbarItem` should know that it's `focusable` as well, so it will add the item to the focus group, even though it's "virtually" `disabled` (only `aria-disabled` is set).

On the GIF below (after the changes on this PR), arrow keys and tabbing works properly.

![Nov-08-2019 01-33-23](https://user-images.githubusercontent.com/3068563/68450047-48853d80-01c8-11ea-956b-553181b5f12c.gif)