### PR TITLE
[Doc] update a broken link to example archive

### DIFF
--- a/packages/villain-react/README.md
+++ b/packages/villain-react/README.md
@@ -106,7 +106,7 @@ To start the development run `yarn start`, this will open up `localhost:8080` on
 
 - This uses webpack-dev-server and includes hot-reloading.
 
-An example archive has been provided to play around inside [`./build/testFile`](https://github.com/btzr-io/Villain/tree/master/build/testFile)
+An example archive has been provided to play around inside [`./packages/villain-react/dev-sandbox/static/archives`](https://github.com/xgirma/Villain/tree/master/packages/villain-react/dev-sandbox/static/archives)
 
 - A good resource for archives can be found here: https://archive.org/details/comics.
 - Alternative, any compressed folder (zip, rar, tar, etc) with a few images will also do the job.

--- a/packages/villain-web/README.md
+++ b/packages/villain-web/README.md
@@ -104,7 +104,7 @@ To start the development run `yarn start`, this will open up `localhost:8080` on
 
 - This uses webpack-dev-server and includes hot-reloading.
 
-An example archive has been provided to play around inside [`./build/testFile`](https://github.com/btzr-io/Villain/tree/master/build/testFile)
+An example archive has been provided to play around inside [`./packages/villain-web/dev-server/static/archives`](https://github.com/xgirma/Villain/tree/master/packages/villain-web/dev-server/static/archives)
 
 - A good resource for archives can be found here: https://archive.org/details/comics.
 - Alternative, any compressed folder (zip, rar, tar, etc) with a few images will also do the job.


### PR DESCRIPTION
## PR Checklist

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [x] Documentation changes
- [ ] Other - Please describe:

## Fixes

Issue Number:

## What is the current behavior? 
The example archive link point to non-existent file.

## What is the new behavior? 
The example archive link now point to an existing archive file. 

## Other information
It was hard for me to find an example to try Villain at first. I even build the code hoping to get the archive from the build archive. With this update others could easily get the archive.
